### PR TITLE
utils：proxy upgrade

### DIFF
--- a/utils/proxy.py
+++ b/utils/proxy.py
@@ -22,6 +22,8 @@ def delete_proxy(proxy):
 def my_get_proxy() -> dict:
     if IS_PROXY:
         content = get_proxy()
+        while not content.get("https"):
+            content = get_proxy()
         proxy = content.get("proxy")
         _proxy = {"http": "http://{}".format(proxy),"https": "http://{}".format(proxy)}
         return _proxy


### PR DESCRIPTION
我在源代码的基础上略做了些修改，使得获取ip时可以直接获取支持https协议的地址，减少了由于选择错误导致部分报错，但是仍旧会有报错的原因是proxypool本身代理的不稳定和一些境外ip会被携程不通过的原因导致的，建议使用的时候将config的timeout设置为10


I have made some slight modifications on the basis of the source code, so that when obtaining the IP, you can directly obtain the address that supports the HTTPS protocol, which reduces some errors caused by the wrong selection, but there will still be errors due to the instability of the proxy of the proxy itself and the reason that some overseas IPs will not be passed by Ctrip, it is recommended to set the timeout of the config to 10 when you use it